### PR TITLE
Sequence tagging

### DIFF
--- a/NLP/project/3_sequence_tagging.ipynb
+++ b/NLP/project/3_sequence_tagging.ipynb
@@ -511,11 +511,11 @@
         "print(\"##################\")"
       ],
       "metadata": {
-        "id": "kcB0gEKXyiwk",
-        "outputId": "4d400ea4-53a9-4112-bebe-efb401b8f903",
         "colab": {
           "base_uri": "https://localhost:8080/"
-        }
+        },
+        "id": "kcB0gEKXyiwk",
+        "outputId": "4d400ea4-53a9-4112-bebe-efb401b8f903"
       },
       "execution_count": 7,
       "outputs": [
@@ -609,11 +609,11 @@
         "print(\"##################\")"
       ],
       "metadata": {
-        "id": "jJgmKpYQ0LG2",
-        "outputId": "00a7c61e-6c68-461b-8f14-8267cc151bd9",
         "colab": {
           "base_uri": "https://localhost:8080/"
-        }
+        },
+        "id": "jJgmKpYQ0LG2",
+        "outputId": "00a7c61e-6c68-461b-8f14-8267cc151bd9"
       },
       "execution_count": 8,
       "outputs": [
@@ -680,7 +680,9 @@
       "execution_count": null,
       "metadata": {
         "id": "LXym_OtkaHly",
-        "outputId": "07aa7126-1df5-4c54-acdc-3b6130f775eb"
+        "outputId": "07aa7126-1df5-4c54-acdc-3b6130f775eb",
+        "collapsed": true,
+        "cellView": "form"
       },
       "outputs": [
         {
@@ -698,6 +700,7 @@
         }
       ],
       "source": [
+        "#@title\n",
         "\n",
         "# Convert the input sequence into an integer one.\n",
         "# The mapping is recorded in the dictionnary to_ix\n",
@@ -733,6 +736,68 @@
         "print(\"#### in the prepared version\")\n",
         "print(\"The sentence : \", prepare_sequence(training_data[0][0],word_to_ix))\n",
         "print(\"The tag seq. : \", prepare_sequence(training_data[0][1],tag_to_ix))"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Convert the input sequence into an integer one.\n",
+        "# The mapping is recorded in the dictionnary to_ix\n",
+        "def prepare_sequence(seq, to_ix):\n",
+        "  idxs = [to_ix[w] for w in seq]\n",
+        "  tensor = torch.LongTensor(idxs)\n",
+        "  return tensor\n",
+        "\n",
+        "# Toy dataset\n",
+        "training_data = [\n",
+        "    (\"The dog ate the apple\".split(), [\"DET\", \"NN\", \"V\", \"DET\", \"NN\"]),\n",
+        "    (\"Everybody read that book\".split(), [\"NN\", \"V\", \"DET\", \"NN\"])\n",
+        "]  \n",
+        "\n",
+        "# The dictionnary : word -> index\n",
+        "word_to_ix = {}\n",
+        "# The other : tag -> index\n",
+        "tag_to_ix = {}\n",
+        "# Build them\n",
+        "for sent, tags in training_data:\n",
+        "  for word in sent:\n",
+        "    if word not in word_to_ix:\n",
+        "      word_to_ix[word] = len(word_to_ix)\n",
+        "  for tag in tags:\n",
+        "    if tag not in tag_to_ix:\n",
+        "      tag_to_ix[tag] = len(word_to_ix) #_to_ix[tag] = len(tag_to_ix)\n",
+        "##\n",
+        "print(\"Words dict; \", word_to_ix)    \n",
+        "print(\"Tags dict: \",tag_to_ix)\n",
+        "\n",
+        "print(\"The sentence : \", training_data[0][0])\n",
+        "print(\"The tag seq. : \", training_data[0][1])\n",
+        "print(\"#### in the prepared version\")\n",
+        "print(\"The sentence : \", prepare_sequence(training_data[0][0], word_to_ix))\n",
+        "print(\"The tag seq. : \", prepare_sequence(training_data[0][1], tag_to_ix))"
+      ],
+      "metadata": {
+        "id": "MZgXDHWp54iv",
+        "outputId": "76171bc5-951b-424d-c2be-86854d32988f",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
+      },
+      "execution_count": 10,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Words dict;  {'The': 0, 'dog': 1, 'ate': 2, 'the': 3, 'apple': 4, 'Everybody': 5, 'read': 6, 'that': 7, 'book': 8}\n",
+            "Tags dict:  {'DET': 5, 'NN': 5, 'V': 5}\n",
+            "The sentence :  ['The', 'dog', 'ate', 'the', 'apple']\n",
+            "The tag seq. :  ['DET', 'NN', 'V', 'DET', 'NN']\n",
+            "#### in the prepared version\n",
+            "The sentence :  tensor([0, 1, 2, 3, 4])\n",
+            "The tag seq. :  tensor([5, 5, 5, 5, 5])\n"
+          ]
+        }
       ]
     },
     {


### PR DESCRIPTION
The task of sequence tagging consists in the attribution of a tag (or a class) to each element (or words ) of a sequence (a sentence):

- An observation is a sentence represented as a word sequence;
- A tag sequence is associated to this sentence, one tag per word.

If the input is sequence of symbols : 
$w_1, \dots, w_M$, with $w_i \in V$, the vocabulary or the finite set of the known words. Assume we have a tagset $T$ le *tagset* which is the set of all possible tags (the output space). At time $i$,  $y_i$ is the tag associated to the word  $w_i$.
The prediction of the model is  $\hat{y}_i$. 
Our goal is to predict the sequence $\hat{y}_1, \dots, \hat{y}_M$, with $\hat{y}_i \in T$.